### PR TITLE
[KR] Accept a restriction matrix as smallModel in KRmodcomp()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+pbkrtest 0.5.6
+============================================
+
+Changes:
+
+* `KRmodcomp()` again accepts a restriction matrix as `smallModel`, as
+  documented. The internal worker no longer calls `formula()` on the matrix
+  (which raised "invalid formula") and stores the matrix for printing (#15).
+
+
 pbkrtest 0.5.5 (Release date: 2025-07-04)
 ============================================
 

--- a/R/KR_modcomp.R
+++ b/R/KR_modcomp.R
@@ -156,16 +156,10 @@ KRmodcomp_worker <- function(largeModel, smallModel, betaH=0, details=0) {
     stats <- .KR_adjust(PhiA, Phi=vcov(largeModel), L, beta=fixef(largeModel), betaH)
     stats <- lapply(stats, c) ## To get rid of all sorts of attributes
     
-    formula.small <-
-        if (.is.lmm(smallModel)){
-            .zzz <- formula(smallModel)
-            attributes(.zzz) <- NULL
-            .zzz
-        } else {
-            list(L = L, betaH = betaH)
-        }
+    ## Keep the formula class intact (so the print method recognises it) and
+    ## store the restriction matrix itself when smallModel is given as a matrix.
     formula.large <- formula(largeModel)
-    attributes(formula.large) <- NULL
+    formula.small <- if (.is.lmm(smallModel)) formula(smallModel) else L
 
 
     test = list(
@@ -179,8 +173,8 @@ KRmodcomp_worker <- function(largeModel, smallModel, betaH=0, details=0) {
     out <- list(
         test=test,
         sigma=getME(largeModel, "sigma"),
-        formula.large=formula(largeModel),
-        formula.small=formula(smallModel),
+        formula.large=formula.large,
+        formula.small=formula.small,
         ctime=(proc.time() - t0)[3],
         L=L
     )


### PR DESCRIPTION
Found during an LLM-assisted bug hunt and reviewed by me.

The documentation states that `smallModel` may be a restriction matrix `L`, but `KRmodcomp_worker()` re-evaluated `formula(smallModel)` when building its output. When `smallModel` is a matrix this calls `formula()` on a matrix and raises `invalid formula`. (The worker already computed a usable `formula.small`/`formula.large` locally, but the output list ignored them and re-called `formula()`.)

This also breaks the package's own `KRmodcomp(fm1, L1)` example, so `R CMD check` currently fails on the examples - this PR repairs that.

### Fix

Store the model formula (class intact, so the print method recognises it) or, for the restriction-matrix case, the matrix `L` itself - which `prform()` already knows how to print.

```r
library(pbkrtest); library(lme4)
fm1 <- lmer(sugpct ~ block + sow + harvest + (1 | block:harvest), data = beets)
L   <- pbkrtest:::model2restriction_matrix(fm1, update(fm1, . ~ . - harvest))

KRmodcomp(fm1, L)
#> before: Error: invalid formula
#> after:  KR  F = 15.21, ddf = 2, p = 0.060   (identical to KRmodcomp(fm1, fm0))
```

The model-based and formula/string forms of `smallModel` are unaffected.

The package currently has no test suite, so I kept this PR to the fix itself. I'd be glad to add a regression test if you'd welcome introducing `testthat` (see #17).

Refs #17.
