### PR TITLE
[accessors] getKR()/getSAT(): return requested components instead of NULL

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+pbkrtest 0.5.6
+============================================
+
+Changes:
+
+* `getKR()` and `getSAT()` no longer return `NULL` for documented component
+  names. The accessors now read the harmonized `$test` output and map names
+  such as `Fstat`/`ndf` onto its columns; `getKR()` previously read a
+  non-existent `$stats` slot. The unavailable name "aux" was dropped (#11).
+
+
 pbkrtest 0.5.5 (Release date: 2025-07-04)
 ============================================
 

--- a/R/get_info_functions.R
+++ b/R/get_info_functions.R
@@ -155,15 +155,26 @@ getLRT.gls <- function(fit1, fit0) {
 #'
 #' @export
 #' @rdname get_modcomp
-getKR <- function (object, name = c("ndf", "ddf", "Fstat", "p.value", "F.scaling", "FstatU", "p.valueU", "aux")) 
-{	
+getKR <- function (object, name = c("ndf", "ddf", "Fstat", "p.value", "F.scaling", "FstatU", "p.valueU"))
+{
   stopifnot(is(object, "KRmodcomp"))
   if (missing(name) || is.null(name)){
-    return(object$stats)
+    return(object$test)
   } else {
     stopifnot(length(name <- as.character(name)) == 1)
     name <- match.arg(name)
-    object$stats[[name]]
+    ## Map the documented accessor names onto the harmonized output in
+    ## `object$test`, a data frame with rows "KR" (scaled) and "KRU"
+    ## (unscaled) and columns statistic/df/ddf/F.scaling/p.value.
+    tab <- object$test
+    switch(name,
+           ndf       = tab["KR",  "df"],
+           ddf       = tab["KR",  "ddf"],
+           Fstat     = tab["KR",  "statistic"],
+           p.value   = tab["KR",  "p.value"],
+           F.scaling = tab["KR",  "F.scaling"],
+           FstatU    = tab["KRU", "statistic"],
+           p.valueU  = tab["KRU", "p.value"])
   }
 }
 
@@ -174,11 +185,18 @@ getSAT <- function (object, name = c("ndf", "ddf", "Fstat", "p.value"))
 {	
   stopifnot(is(object, "SATmodcomp"))
   if (missing(name) || is.null(name)){
-    return(object$test) ## FIXME Should be stats
+    return(object$test)
   } else {
     stopifnot(length(name <- as.character(name)) == 1)
     name <- match.arg(name)
-    object$test[[name]] ## FIXME Should be stats
+    ## Map the documented accessor names onto the harmonized output in
+    ## `object$test` (columns statistic/df/ddf/p.value).
+    tab <- object$test
+    switch(name,
+           ndf     = tab[["df"]],
+           ddf     = tab[["ddf"]],
+           Fstat   = tab[["statistic"]],
+           p.value = tab[["p.value"]])
   }
 }
 

--- a/man/get_modcomp.Rd
+++ b/man/get_modcomp.Rd
@@ -9,7 +9,7 @@
 \usage{
 getKR(
   object,
-  name = c("ndf", "ddf", "Fstat", "p.value", "F.scaling", "FstatU", "p.valueU", "aux")
+  name = c("ndf", "ddf", "Fstat", "p.value", "F.scaling", "FstatU", "p.valueU")
 )
 
 getSAT(object, name = c("ndf", "ddf", "Fstat", "p.value"))


### PR DESCRIPTION
Found during an LLM-assisted bug hunt and reviewed by me.

After the test outputs were harmonized (columns `statistic` / `df` / `ddf` / `p.value`), the accessors were not updated:

- `getSAT()` returns `NULL` for `"Fstat"` and `"ndf"` (it indexes by those names, but the columns are now `statistic` / `df`).
- `getKR()` returns `NULL` for **every** name because it reads a non-existent `$stats` slot - the values live in `$test`.

### Fix

Read `$test` and map the documented accessor names onto the harmonized columns. `getKR()` additionally distinguishes the scaled (`"KR"`) and unscaled (`"KRU"`) rows for `FstatU` / `p.valueU`. The name `"aux"` is dropped, as the harmonized output no longer provides it.

```r
library(pbkrtest); library(lme4)
fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy)
fm0 <- lmer(Reaction ~ (Days | Subject), sleepstudy)

getSAT(SATmodcomp(fm1, fm0), "Fstat")  #> before: NULL   after: the F statistic
getKR(KRmodcomp(fm1, fm0),   "ddf")    #> before: NULL   after: 17
```

Note: `R CMD check` on this branch still errors on the unrelated `KRmodcomp(fm1, L1)` example - that is the separate restriction-matrix regression, fixed by the companion PR #18. This PR's own examples pass.

The package currently has no test suite, so this PR is just the fix. Happy to add a regression test if you'd welcome introducing `testthat` (see #17).

Refs #17.
